### PR TITLE
Updates StatsD to version v0.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM mhart/alpine-node
 
 RUN apk add --update git
 
-RUN git clone https://github.com/etsy/statsd.git /opt/statsd &&\
+RUN git clone https://github.com/statsd/statsd.git /opt/statsd &&\
         cd /opt/statsd &&\
         git checkout v0.7.2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --update git
 
 RUN git clone https://github.com/statsd/statsd.git /opt/statsd &&\
         cd /opt/statsd &&\
-        git checkout v0.7.2
+        git checkout v0.8.2
 
 COPY ./config.js /opt/statsd/
 


### PR DESCRIPTION
This PR:

- [x] Updates StatsD repository from etsy namespace to the new statsd one -- as mentioned on https://github.com/statsd/statsd/issues/649;
- [x] Upgrades StatsD to `v0.8.2` since `v0.7.2` has compatibility issues with nodejs > v6.

This was motivated by the reported issue #1 where the used nodejs version doesn't work on the last nodejs version used in our `alpine-node` image.